### PR TITLE
Enhancements to tiny OLEDs, OTA beautified

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.pio
+.vscode

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ New version of the well known ESP32 Radio.  Now optional I2S output and SP/DIF o
 ![SAM_2922](https://github.com/Edzelf/ESP32Radio-V2/assets/18257026/a58f7b7e-cdd4-4d7f-96b8-62fa487de906)
 
 Updates:
+- 30-sep-2024: Enhancements to tiny OLEDs, OTA beautified (Trip5 Update).
 - 05-jul-2024: Correction SPDIF output.
 - 12-mar-2024: Add document with building instructions.  New PCB available! See [here at PCBWay](https://www.pcbway.com/project/shareproject/W652317AS2P1_Gerber_ESP32_Radio_PCB_ESP32_Radio_fab8a6d9.html).
 - 19-feb-2024: SP/DIF (Toslink) output, fixed mono bug.

--- a/data/defaultprefs.txt
+++ b/data/defaultprefs.txt
@@ -43,6 +43,9 @@ preset_09 = server-27.stream-server.nl:8192/stream   #  9 - 192 Radio Nederland,
 clk_server = pool.ntp.org                            # Time server to be used
 clk_offset = 1                                       # Offset with respect to UTC in hours
 clk_dst = 1                                          # Offset during daylight saving time (hours)
+# Screensaving Options
+disp_time = 45                                       # Turn off backlight / blank display (seconds)
+disp_blank = true                                    # Enables blanking the display
 # Some example IR codes
 ir_40BF = upvolume = 2
 ir_C03F = downvolume = 2

--- a/doc/example config.txt
+++ b/doc/example config.txt
@@ -74,3 +74,6 @@ volume = 100
 #
 wifi_00 = ADSL-11/DEADC0DE11
 wifi_01 = MoniNet/m1234m1234
+#
+disp_time = 45          # Turn off backlight / blank display (seconds)
+disp_blank = true       # Enables blanking the display

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4063,7 +4063,7 @@ const char* analyzeCmd ( const char* str )
 //   bat0       = 2318                      // ADC value for an empty battery                      *
 //   bat100     = 2916                      // ADC value for a fully charged battery               *
 //   disp_time = 45                         // Turns off backlight / blanks display in x seconds   *
-//   disp_blank = false                     // Allows blanking of display                          *
+//   disp_blank = false                     // Allows blanking of display *)                       *
 //  Commands marked with "*)" are sensible during initialization only                              *
 //**************************************************************************************************
 const char* analyzeCmd ( const char* par, const char* val )

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -106,10 +106,11 @@
 // 16-02-2024, ES: SPDIFF output (experimental).
 // 19-02-2024, ES: Fixed mono stream, correct handling of reset command.
 // 27-06-2024, ES: Simplified WiFi network set.
-
+// 30-09-2024, Trip5: OLED 64x128 improvements: blank screen with backlight time (both available in prefs),
+//             character limit for small displays.  Also: OTA beautified, fixed rotary timeout display, new esp-idf ADC.
 //
 // Define the version number, the format used is the HTTP standard.
-#define VERSION     "Fri, 05 Jul 2024 13:40:00 GMT"
+#define VERSION     "Mon, 29 Sep 2024 22:00:00 GMT"
 //
 #include <Arduino.h>                                      // Standard include for Platformio Arduino projects
 #include "soc/soc.h"                                      // For brown-out detector setting
@@ -172,7 +173,7 @@
 #define MAXPRESETS        200                             // Max number of presets in preferences
 #define MAXMQTTCONNECTS   5                               // Maximum number of MQTT reconnects before give-up
 #define METASIZ           1024                            // Size of metaline buffer
-#define BL_TIME           45                              // Time-out [sec] for blanking TFT display (BL pin)
+#define BL_TIME           45                              // Time-out [sec] for blanking TFT display (BL pin) (this used if not in prefs)
 //
 // Subscription topics for MQTT.  The topic will be pefixed by "PREFIX/", where PREFIX is replaced
 // by the the mqttprefix in the preferences.  The next definition will yield the topic
@@ -272,6 +273,8 @@ struct ini_struct
   int8_t         eth_power_pin ;                      // GPIO Pin number for Ethernet controller POWER
   uint16_t       bat0 ;                               // ADC value for 0 percent battery charge
   uint16_t       bat100 ;                             // ADC value for 100 percent battery charge
+  uint16_t       disp_time ;                          // Turns off backlight or blanks display
+  bool           disp_blank ;                         // Enable blanking of the display
 } ;
 
 struct WifiInfo_t                                     // For list with WiFi info
@@ -369,6 +372,7 @@ uint16_t             adcvalraw ;                         // ADC value (raw)
 uint16_t             adcval ;                            // ADC value (battery voltage, averaged)
 uint32_t             clength ;                           // Content length found in http header
 uint16_t             bltimer = 0 ;                       // Backlight time-out counter
+bool                 disp_data = true ;                  // Sending data to display is OK?
 bool                 dsp_ok = false ;                    // Display okay or not
 int                  ir_intcount = 0 ;                   // For test IR interrupts
 bool                 spftrigger = false ;                // To trigger execution of special functions
@@ -982,10 +986,14 @@ void IRAM_ATTR timer100()
       }
     }
     time_req = true ;                             // Yes, show current time request
-    if ( ++bltimer == BL_TIME )                   // Time to blank the TFT screen?
+    if ( ++bltimer == ini_block.disp_time )       // Time to blank/turn of backlight?
     {
       bltimer = 0 ;                               // Yes, reset counter
       blset ( false ) ;                           // Disable TFT (backlight)
+      if ( ini_block.disp_blank == true )         // Is the Display blanking option on?
+      {
+        disp_data = false ;                       // Turn off sending data to display
+      }
     }
   }
   // Handle rotary encoder. Inactivity counter will be reset by encoder interrupt
@@ -1572,33 +1580,95 @@ bool connectwifi()
 
 #ifdef ENABLEOTA
 //**************************************************************************************************
-//                                           O T A S T A R T                                       *
+//                                         O T A S E T U P                                         *
 //**************************************************************************************************
 // Update via WiFi/Ethernet has been started by Arduino IDE or PlatformIO.                         *
 //**************************************************************************************************
-void otastart()
+void otasetup()
 {
-  const char* p = "OTA update Started" ;
+  ArduinoOTA.setRebootOnSuccess(true);
 
-  ESP_LOGI ( TAG, "%s", p ) ;                      // Show event for debug
-  tftset ( 2, p ) ;                                // Set screen segment bottom part
-  mp3client->abort() ;                             // Stop client
-  timerAlarmDisable ( timer ) ;                    // Disable the timer
-  disableCore0WDT() ;                              // Disable watchdog core 0
-  disableCore1WDT() ;                              // Disable watchdog core 1
-  queueToPt ( QSTOPTASK ) ;                        // Queue a request to stop the song
-}
+  ArduinoOTA.onStart([]() {
+    const char* msga = "OTA Update Started" ;
+    const char* msgb = "" ;
+    if ( ArduinoOTA.getCommand() == U_FLASH ) {
+      msgb = "Type: sketch";
+    } else {
+      msgb = "Type: filesystem" ;                     // U_SPIFFS, U_LITTLEFS
+    }
+    ESP_LOGI ( TAG, "%s", msga ) ;                    // Show messages in debug
+    ESP_LOGI ( TAG, "%s", msgb ) ;
+    if ( dsp_ok )                                     // Init okay?
+    {
+      disp_data = true ;                              // Turn on display (if off)
+      dsp_erase() ;                                   // Clear screen
+      dsp_setCursor ( 0, 0 ) ;                        // Top of screen
+      dsp_println ( msga ) ;                          // Show messages on screen
+      dsp_println ( msgb ) ;
+      dsp_update ( enc_menu_mode == VOLUME ) ;        // Show on physical screen if needed
+    }
+    mp3client->abort() ;                              // Stop client
+    timerAlarmDisable ( timer ) ;                     // Disable the timer
+    disableCore0WDT() ;                               // Disable watchdog core 0
+    disableCore1WDT() ;                               // Disable watchdog core 1
+    queueToPt ( QSTOPTASK ) ;                         // Queue a request to stop the song
+  });
 
+  ArduinoOTA.onProgress([](unsigned int progress, unsigned int total) {
+    ESP_LOGI ( TAG, "Progress: %u%%\n", (progress / (total / 100))); // Show event for debug
+    if ( dsp_ok )                                     // Init okay?
+    {
+      displayvolume ( progress * 100 / total ) ;      // Show progress as volume on display
+      dsp_update ( enc_menu_mode == VOLUME ) ;        // Show on physical screen if needed
+    }
+  });
 
-//**************************************************************************************************
-//                                           O T A E R R O R                                       *
-//**************************************************************************************************
-// Update via WiFi has an error.                                                                   *
-//**************************************************************************************************
-void otaerror ( ota_error_t error)
-{
-  ESP_LOGE ( TAG, "OTA error %d", error ) ;
-  tftset ( 2, "OTA error!" ) ;                        // Set screen segment bottom part
+  ArduinoOTA.onEnd([]() {
+    const char* msg = "OTA Done!" ;
+    displayvolume ( 100 ) ;                           // Show volume on display
+    ESP_LOGI ( TAG, "%s", msg ) ;                     // Show message in debug
+    if ( dsp_ok )                                     // Init okay?
+    {
+      dsp_println ( "" ) ;                            // Add a blank line to screen
+      dsp_println ( msg ) ;                           // Show message on screen
+      dsp_update ( enc_menu_mode == VOLUME ) ;        // Show on physical screen if needed
+    }
+  });
+
+  ArduinoOTA.onError([](ota_error_t error) {
+    const char* msga = "OTA Error" ;
+    const char* msgb = "" ;
+    if ( error == OTA_AUTH_ERROR )
+    {
+      msgb = "Authentication Failed" ;
+    }
+    else if ( error == OTA_BEGIN_ERROR )
+    {
+      msgb = "Begin Failed" ;
+    } 
+    else if ( error == OTA_CONNECT_ERROR )
+    {
+      msgb = "Connection Failed" ;
+    }
+    else if ( error == OTA_RECEIVE_ERROR )
+    {
+      msgb = "Receive Failed" ;
+    }
+    else if ( error == OTA_END_ERROR )
+    {
+      msgb = "End Failed" ;
+    }
+    ESP_LOGI ( TAG, "%s", msga ) ;                    // Show messages in debug
+    ESP_LOGI ( TAG, "%s", msgb ) ;
+    if ( dsp_ok )                                     // Init okay?
+    {
+      dsp_println ( msga ) ;                          // Show messages on screen
+      dsp_println ( msgb ) ;
+      dsp_update ( enc_menu_mode == VOLUME ) ;        // Show on physical screen if needed
+    }
+  });
+
+  ArduinoOTA.begin();                                 // Initialize
 }
 #endif                                                // ENABLEOTA
 
@@ -2484,6 +2554,9 @@ void setup()
   ini_block.clk_dst = 1 ;                                // DST is +1 hour
   ini_block.bat0 = 2600 ;                                // Battery ADC level for 0 percent
   ini_block.bat100 = 2950 ;                              // Battery ADC level for 100 percent
+  ini_block.disp_time = BL_TIME ;                        // Use defined BL_TIME as default
+  ini_block.disp_blank = false ;                         // Screen blanking off by default
+  
   readIOprefs() ;                                        // Read pins used for SPI, TFT, VS1053, IR,
                                                          // Rotary encoder
   for ( i = 0 ; (pinnr = progpin[i].gpio) >= 0 ; i++ )   // Check programmable input pins
@@ -2544,6 +2617,7 @@ void setup()
     pinMode ( ini_block.tft_blx_pin, OUTPUT ) ;          // Yes, enable output
   }
   blset ( true ) ;                                       // Enable backlight (if configured)
+  disp_data = true ;                                     // Turn on sending data to display
   #ifndef ETHERNET
     mk_lsan() ;                                          // Make a list of acceptable networks
                                                          // in preferences.
@@ -2591,10 +2665,7 @@ void setup()
     mqtt_on = ( ini_block.mqttbroker.length() > 0 ) &&   // Use MQTT if broker specified
               ( ini_block.mqttbroker != "none" ) ;
     #ifdef ENABLEOTA
-      ArduinoOTA.setHostname ( NAME ) ;                  // Set the hostname
-      ArduinoOTA.onStart ( otastart ) ;
-      ArduinoOTA.onError ( otaerror ) ;
-      ArduinoOTA.begin() ;                               // Allow update over the air
+      otasetup();                                        // Call to set up OTA
     #endif
     if ( mqtt_on )                                       // Broker specified?
     {
@@ -2668,7 +2739,7 @@ void setup()
     gettime() ;                                           // Sync time
   }
   adc1_config_width ( ADC_WIDTH_12Bit ) ;
-  adc1_config_channel_atten ( ADC1_CHANNEL_0, ADC_ATTEN_DB_11 ) ;  // VP/GPIO36
+  adc1_config_channel_atten ( ADC1_CHANNEL_0, ADC_ATTEN_DB_12 ) ;  // VP/GPIO36 (old esp-idf 11, now 12)
   xTaskCreatePinnedToCore (
     playtask,                                             // Task to play data in dataqueue.
     "Playtask",                                           // Name of task.
@@ -3003,6 +3074,36 @@ void handleVolPub()
 
 
 //**************************************************************************************************
+//                                    R E D R A W D I S P L A Y                                    *
+//**************************************************************************************************
+// Fully redraws entire display (0) or some part: top (1) middle (2) bottom (3)                    *
+//**************************************************************************************************
+void redrawdisplay(int8_t i)
+{
+  disp_data = true ;
+  if (i == 0 || i == 1)
+  {
+      tftset ( 0, NAME ) ;                                    // Set screen segment text top line
+      displaytime ( "" ) ;                                    // Clear time on TFT screen
+      displaytime ( timetxt ) ;                               // Write to TFT screen
+      displaybattery ( 0, 100, 0 ) ;                          // Actually this draws an
+      displaybattery ( ini_block.bat0, ini_block.bat100,      // Show battery charge on display
+                       adcval ) ;
+  }
+  if (i == 0 || i == 2)
+  {
+      if ( showstreamtitle ( ("StreamTitle=" + icystreamtitle).c_str() ) ) { } // Stream Title
+  }
+  if (i == 0 || i == 3)
+  {
+      displayvolume ( 0 ) ;                                   // Forget previous value
+      displayvolume ( player_getVolume() ) ;                  // Show volume on display
+      tftset ( 2, icyname ) ;                                 // Restore screen segment bottom part
+  }
+}
+
+
+//**************************************************************************************************
 //                                           C H K _ E N C                                         *
 //**************************************************************************************************
 // See if rotary encoder is activated and perform its functions.                                   *
@@ -3019,13 +3120,22 @@ void chk_enc()
       enc_inactivity = 0 ;
       enc_menu_mode = VOLUME ;                                // Return to VOLUME mode
       ESP_LOGI ( TAG, "Encoder mode back to VOLUME" ) ;
+      redrawdisplay(3) ;
     }
   }
   if ( singleclick || doubleclick ||                          // Any activity?
        tripleclick || longclick ||
        ( rotationcount != 0 ) )
   {
-    blset ( true ) ;                                          // Yes, activate display if needed
+    blset ( true ) ;                                          // Yes, activate display backlight if needed
+    if ( !disp_data )                                         // Turn on sending data to display (and do full redraw)
+    {
+      if ( !muteflag && singleclick )                         // If it was muted, single-click allows unmute...
+      {
+        singleclick = false ;                                 // otherwise only wakes up the screen instead of muting
+      }
+      redrawdisplay(0) ;
+    }
   }
   else
   {
@@ -3056,8 +3166,13 @@ void chk_enc()
     doubleclick = false ;
     enc_menu_mode = PRESET ;                                  // Swich to PRESET mode
     ESP_LOGI ( TAG, "Encoder mode set to PRESET" ) ;
-    tftset ( 3, "Turn to select station\n"                    // Show current option
+    #if defined(OLED1306) || defined(OLED1309) || defined(OLED1106) // Fix fit for small displays
+      tftset ( 3, "Turn & choose station"                     // Show current option
                 "Press to confirm" ) ;
+    #else
+      tftset ( 3, "Turn to select station\n"                  // Show current option
+                "Press to confirm" ) ;
+    #endif
     enc_preset = presetinfo.preset ;                          // Start with current preset
     updateNr ( &enc_preset, presetinfo.highest_preset,        // plus 1
                1, true ) ;
@@ -3194,7 +3309,7 @@ void spfuncs()
   if ( spftrigger )                                             // Will be set every 100 msec
   {
     spftrigger = false ;                                        // Reset trigger
-    if ( dsp_ok )                                               // Posible to update TFT?
+    if ( dsp_ok && disp_data )                                  // Posible to update Display?
     {
       for ( uint16_t i = 0 ; i < TFTSECS ; i++ )                // Yes, handle all sections
       {
@@ -3207,6 +3322,11 @@ void spfuncs()
         }
       }
       dsp_update ( enc_menu_mode == VOLUME ) ;                  // Be sure to paint physical screen
+    }
+    if ( dsp_ok && !disp_data )                                 // Clear the screen if not being used...
+    {
+      dsp_erase() ;                                             // Clear screen
+      dsp_update ( enc_menu_mode == VOLUME ) ;                  // Show on physical screen if needed
     }
     if ( muteflag )                                             // Mute or not?
     {
@@ -3228,10 +3348,14 @@ void spfuncs()
         gettime() ;                                             // Yes, get the current time
       }
       time_req = false ;                                        // Yes, clear request
-      displaytime ( timetxt ) ;                                 // Write to TFT screen
-      displayvolume ( player_getVolume() ) ;                    // Show volume on display
-      displaybattery ( ini_block.bat0, ini_block.bat100,        // Show battery charge on display
+
+      if ( disp_data )                                          // Sending data to display is OK?
+      {
+        displaytime ( timetxt ) ;                               // Write to TFT screen
+        displayvolume ( player_getVolume() ) ;                  // Show volume on display
+        displaybattery ( ini_block.bat0, ini_block.bat100,      // Show battery charge on display
                        adcval ) ;
+      }
     }
     if ( mqtt_on )
     {
@@ -3938,6 +4062,8 @@ const char* analyzeCmd ( const char* str )
 //   reset                                  // Restart the ESP32                                   *
 //   bat0       = 2318                      // ADC value for an empty battery                      *
 //   bat100     = 2916                      // ADC value for a fully charged battery               *
+//   disp_time = 45                         // Turns off backlight / blanks display in x seconds *)*
+//   disp_blank = false                     // Allows blanking of display *)                       *
 //  Commands marked with "*)" are sensible during initialization only                              *
 //**************************************************************************************************
 const char* analyzeCmd ( const char* par, const char* val )
@@ -3950,6 +4076,7 @@ const char* analyzeCmd ( const char* par, const char* val )
   bool               relative = false ;               // Relative argument (+ or -)
 
   blset ( true ) ;                                    // Enable backlight of TFT
+  disp_data = true ;                                  // Turn on sending data to display
   strcpy ( reply, "Command accepted" ) ;              // Default reply
   argument = String ( par ) ;                         // Get the argument
   chomp ( argument ) ;                                // Remove comment and useless spaces
@@ -4162,6 +4289,25 @@ const char* analyzeCmd ( const char* par, const char* val )
       ini_block.bat0 = ivalue ;                       // Yes, set it
     }
   }
+  else if ( argument.startsWith ( "disp_" ) )         // Disp_ value?
+  {
+    if ( argument.indexOf ( "time" ) > 0 )            // Time to turn off backlight or blank?
+    {
+      ini_block.disp_time = ivalue ;                  // Yes, set time
+      if ( ini_block.disp_time <= 2 )                 // 2 seconds or less is silly
+      {
+        ini_block.disp_time = BL_TIME ;
+      }
+    }
+    else if ( argument.indexOf ( "blank" ) )          // Blank the screen?
+    {
+      if ( value.startsWith ("true" ) )               // True? (default False)
+      {
+        ini_block.disp_blank = true ;
+      }
+    }
+  }
+
   else
   {
     sprintf ( reply, "%s called with illegal parameter: %s",
@@ -4170,6 +4316,41 @@ const char* analyzeCmd ( const char* par, const char* val )
   return reply ;                                      // Return reply to the caller
 }
 
+#if defined(OLED1306) || defined(OLED1309) || defined(OLED1106) // Only needed by certain displays
+//**************************************************************************************************
+//                                 N E W L I N E S T O S P A C E S                                 *
+//**************************************************************************************************
+// Used by character-limiting routine in displayinfo() - transforms newlines to spaces.            *
+//**************************************************************************************************
+String newlinestospaces(const String& str, uint16_t line_len, uint16_t max_lines) {
+    uint16_t spacedi = 0;                                  // Calculating how many characters are in resulting string 
+    uint16_t spaces = 0;                                   // How many spaces to add when encountering a newline
+    String   spaced = "";                                  // Resulting string with spaces instead of newlines
+
+    if ( str.length() == 0 )
+    {
+        return str;                                        // Return the original string for empty strings (otherwise weird)
+    }
+    for ( size_t i = 0; i < str.length(); ++i ) {
+        if (str[i] == '\n')
+        {                                                  // Calculate how many spaces needed to reach the end of line
+            spaces = ( line_len - ( spaced.length() % line_len ) );
+            for ( size_t sp = 0; sp < spaces; ++sp )
+            {
+                spaced += ' ';                             // Adding spaces to add to reach the next line_len boundary
+            }
+        } else {
+            spaced += str[i];                              // Copy over the current character
+        }
+        spacedi = spaced.length();                         // Update length
+        if ( spacedi >= ( line_len * max_lines ) ) {       // Stop if we've reached the maximum allowed number of characters
+            break;
+        }
+    }
+
+    return spaced;  // Return the newly formatted string by value
+}
+#endif
 
 //**************************************************************************************************
 //* Function that are called from spfunc().                                                        *
@@ -4186,7 +4367,7 @@ void displayinfo ( uint16_t inx )
 {
   uint16_t       width = dsp_getwidth() ;                  // Normal number of colums
   scrseg_struct* p = &tftdata[inx] ;
-  uint16_t len ;                                           // Length of string, later buffer length
+  uint16_t       len ;                                     // Length of string, later buffer length
 
   if ( inx == 0 )                                          // Topline is shorter
   {
@@ -4199,6 +4380,22 @@ void displayinfo ( uint16_t inx )
     {
       dsp_fillRect ( 0, p->y - 4, width, 1, GREEN ) ;      // Yes, show divider above text
     }
+
+    #if defined(OLED1306) || defined(OLED1309) || defined(OLED1106) // Need to limit characters on certain small displays
+      if ( inx == 3 || inx == 2 )                          // 3 streamtitle, menu, mute, messages & 2 icyname = 21 characters x 2 lines
+      {
+        p->str = newlinestospaces( p->str, 21, 2 );
+      }
+      else if (inx == 1 )                                  // 1 song and artist = 21 chars x 4 lines
+      {
+        p->str = newlinestospaces( p->str, 21, 4 );
+      }
+      else if (inx == 0 )                                  // 0 NAME = 21 chars - (8 for time + 1 space))
+      {
+        p->str = newlinestospaces( p->str, 12, 1 );
+      }
+    #endif
+
     len = p->str.length() ;                                // Required length of buffer
     if ( len++ )                                           // Check string length, set buffer length
     {

--- a/tools/Esp32_radio_init.ino
+++ b/tools/Esp32_radio_init.ino
@@ -64,6 +64,9 @@ void setup()
   preferences.putString ( "clk_offset",  "1" ) ;
   preferences.putString ( "clk_dst",     "1" ) ;
   //
+  preferences.putString ( "disp_time",  "45" ) ;
+  preferences.putString ( "disp_blank",  "true" ) ;
+  //
   preferences.putString ( "pin_ir",      "35                                     # GPIO Pin number for IR receiver VS1838B" ) ;
   preferences.putString ( "ir_40BF",     "upvolume = 2" ) ;
   preferences.putString ( "ir_C03F",     "downvolume = 2" ) ;


### PR DESCRIPTION
A quick summary of what's in this (as included in the main.cpp):

OLED 64x128 improvements: blank screen with backlight time (both available in prefs), character limit for small displays.  Also: OTA beautified, fixed rotary timeout display, new esp-idf ADC (the new number is 12 for attenuation instead of 11).

I added a bunch of functions to help with small displays but I think they only apply to the tiny OLEDS.  But they can be applied to other displays should the need arise.

I made a big change to the OTA too.  It looks pretty good on my Tiny OLED.  It didn't display any update information before at all.  It was kind of a PITA to get it working the way it's supposed to.